### PR TITLE
Fix fatal error for offline session on OAuth callback

### DIFF
--- a/src/Auth/OAuth.php
+++ b/src/Auth/OAuth.php
@@ -166,7 +166,7 @@ class OAuth
             );
         }
 
-        $sessionExpiration = ($session->getExpires() ? (int)$session->getExpires()->format('U') : null);
+        $sessionExpiration = ($session->getExpires() ? (int)$session->getExpires()->format('U') : 0);
         $cookieSet = self::setCookieSessionId(
             $setCookieFunction,
             $cookieSessionId,


### PR DESCRIPTION
### WHY are these changes introduced?

(Firstly I hope I'm not wrong with this? I'm using the defauls `setcookie` functions)

When performing OAuth for offline session, it seems like the `Shopify\Auth::callback()` function is trying to set a cookie which can have no expiration (in my case?) and default to `null`. This will cause a fatal error as the `setcookie` function is expcting an array or int.

The error I was getting: Fix fatal error when the callback function is called for offline session (Fatal error: Uncaught TypeError: setcookie(): Argument #3 ($expires_or_options) must be of type array|int, null given).

### WHAT is this pull request doing?

Set the default expiration from `null` to `0`.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
